### PR TITLE
chore: promote gohttp to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.1-release.yaml
@@ -1,0 +1,32 @@
+# Source: gohttp/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-13T16:53:59Z"
+  deletionTimestamp: null
+  name: 'gohttp-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        release 0.0.1
+      sha: 2ee35383f439ecb73c26525f076c2fd3a37e381b
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        chore: Jenkins X build pack
+      sha: 85abca73d5976c3f07556ae5e462d7b1f9a365f8
+  gitCloneUrl: https://github.com/mikelear/gohttp.git
+  gitHttpUrl: https://github.com/mikelear/gohttp
+  gitOwner: mikelear
+  gitRepository: gohttp
+  name: 'gohttp'
+  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
@@ -1,0 +1,57 @@
+# Source: gohttp/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gohttp-gohttp
+  labels:
+    draft: draft-app
+    chart: "gohttp-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: gohttp-gohttp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: gohttp-gohttp
+    spec:
+      containers:
+        - name: gohttp
+          image: "gcr.io/domleartechtech/gohttp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-ingress.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: gohttp/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: gohttp
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: gohttp
+              servicePort: 80
+      host: gohttp-jx-staging.leartech.tech
+  tls:
+    - hosts:
+        - gohttp-jx-staging.leartech.tech
+      secretName: "tls-leartech-tech-p"

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
@@ -1,0 +1,21 @@
+# Source: gohttp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gohttp
+  labels:
+    chart: "gohttp-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: gohttp-gohttp

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -21,6 +21,8 @@ repositories:
   url: https://kubernetes-charts.banzaicloud.com
 - name: jetstack
   url: https://charts.jetstack.io
+- name: dev
+  url: https://chartmuseum-jx.leartech.tech
 releases:
 - chart: jenkins-x/jxboot-helmfile-resources
   version: 1.0.16
@@ -128,5 +130,9 @@ releases:
   values:
   - issuer:
       cluster: true
+- chart: dev/gohttp
+  version: 0.0.1
+  name: gohttp
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote gohttp to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge