### PR TITLE
chore: promote gohttp to version 0.0.2 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-13T16:53:59Z"
+  creationTimestamp: "2020-11-13T17:20:37Z"
   deletionTimestamp: null
-  name: 'gohttp-0.0.1'
+  name: 'gohttp-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -14,19 +14,19 @@ spec:
       branch: master
       committer: {}
       message: |
-        release 0.0.1
-      sha: 2ee35383f439ecb73c26525f076c2fd3a37e381b
+        release 0.0.2
+      sha: 1c1a7d0f82ec6c7ada96fa68506268b53f6ff450
     - author: {}
       branch: master
       committer: {}
       message: |
-        chore: Jenkins X build pack
-      sha: 85abca73d5976c3f07556ae5e462d7b1f9a365f8
+        add a dummy file
+      sha: 0254bb0c61fcad976382d2ad672d01dc2504c3fd
   gitCloneUrl: https://github.com/mikelear/gohttp.git
   gitHttpUrl: https://github.com/mikelear/gohttp
   gitOwner: mikelear
   gitRepository: gohttp
   name: 'gohttp'
-  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gohttp-gohttp
   labels:
     draft: draft-app
-    chart: "gohttp-0.0.1"
+    chart: "gohttp-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,11 +23,11 @@ spec:
     spec:
       containers:
         - name: gohttp
-          image: "gcr.io/domleartechtech/gohttp:0.0.1"
+          image: "gcr.io/domleartechtech/gohttp:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: gohttp
   labels:
-    chart: "gohttp-0.0.1"
+    chart: "gohttp-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -131,7 +131,7 @@ releases:
   - issuer:
       cluster: true
 - chart: dev/gohttp
-  version: 0.0.1
+  version: 0.0.2
   name: gohttp
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote gohttp to version 0.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge