### PR TITLE
chore: promote gohttp to version 0.0.4 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.4-release.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.4-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-14T13:44:42Z"
+  creationTimestamp: "2020-11-14T14:46:01Z"
   deletionTimestamp: null
-  name: 'gohttp-0.0.3'
+  name: 'gohttp-0.0.4'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -14,25 +14,31 @@ spec:
       branch: master
       committer: {}
       message: |
-        release 0.0.3
-      sha: eefba4f8388368b2e456dbee19a54b360cf41678
+        release 0.0.4
+      sha: 214352d35f59d2b9d67968dced7063823846eff5
     - author: {}
       branch: master
       committer: {}
       message: |
-        Change the main.go to trigger a build
-      sha: 3d1cee506e8077e2fb18dcda4da7992f66c07c61
+        Edit yaml
+      sha: 41fbee07016d273f9d280931d9ec2421468d80a1
     - author: {}
       branch: master
       committer: {}
       message: |
-        Change the Ingress to test changes to include the Leartech Domain
-      sha: f4cc6e38ba0665542f3d8c6a6a3ebb22b7f26287
+        Edit yaml
+      sha: 79385849d30c8818936c04fa243785c9573e9378
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        trying some yaml logic to see if I can manage namespace envs
+      sha: 6202eb9dce5c719a84c2626a41d7eff2f1350957
   gitCloneUrl: https://github.com/mikelear/gohttp.git
   gitHttpUrl: https://github.com/mikelear/gohttp
   gitOwner: mikelear
   gitRepository: gohttp
   name: 'gohttp'
-  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.3
-  version: v0.0.3
+  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.4
+  version: v0.0.4
 status: {}

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gohttp-gohttp
   labels:
     draft: draft-app
-    chart: "gohttp-0.0.3"
+    chart: "gohttp-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: gohttp-gohttp
       containers:
         - name: gohttp
-          image: "gcr.io/domleartechtech/gohttp:0.0.3"
+          image: "gcr.io/domleartechtech/gohttp:0.0.4"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.3
+              value: 0.0.4
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-ingress.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-ingress.yaml
@@ -16,21 +16,7 @@ spec:
               serviceName: gohttp
               servicePort: 80
       host: gohttp-jx-staging.leartech.tech
-    - host: www.leartech.tech
-      http:
-        paths:
-          - backend:
-              serviceName: gohttp
-              servicePort: 80
-    - host: leartech.tech
-      http:
-        paths:
-          - backend:
-              serviceName: gohttp
-              servicePort: 80
   tls:
     - hosts:
-        - www.leartech.tech
-        - leartech.tech
         - gohttp-jx-staging.leartech.tech
       secretName: "tls-leartech-tech-p"

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: gohttp
   labels:
-    chart: "gohttp-0.0.3"
+    chart: "gohttp-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -131,7 +131,7 @@ releases:
   - issuer:
       cluster: true
 - chart: dev/gohttp
-  version: 0.0.3
+  version: 0.0.4
   name: gohttp
   namespace: jx-staging
 - chart: dev/gohttp


### PR DESCRIPTION
chore: promote gohttp to version 0.0.4 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge