### PR TITLE
chore: promote gohttp to version 0.0.6 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.6-release.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.6-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-14T17:26:21Z"
+  creationTimestamp: "2020-11-14T17:37:55Z"
   deletionTimestamp: null
-  name: 'gohttp-0.0.5'
+  name: 'gohttp-0.0.6'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -14,19 +14,19 @@ spec:
       branch: master
       committer: {}
       message: |
-        release 0.0.5
-      sha: 2f1383eb3bb4be8fd8257418a02232d4d430c366
+        release 0.0.6
+      sha: 863ba89f3c0d22c085973329df9e50e6da97837c
     - author: {}
       branch: master
       committer: {}
       message: |
-        Redit main to trigger a build
-      sha: 5d0be64497e669467842f252904109daa207233c
+        Test PR certs
+      sha: 2906198a1bfc5fb2877806822edde0c4d5825480
   gitCloneUrl: https://github.com/mikelear/gohttp.git
   gitHttpUrl: https://github.com/mikelear/gohttp
   gitOwner: mikelear
   gitRepository: gohttp
   name: 'gohttp'
-  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.5
-  version: v0.0.5
+  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.6
+  version: v0.0.6
 status: {}

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gohttp-gohttp
   labels:
     draft: draft-app
-    chart: "gohttp-0.0.5"
+    chart: "gohttp-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: gohttp-gohttp
       containers:
         - name: gohttp
-          image: "gcr.io/domleartechtech/gohttp:0.0.5"
+          image: "gcr.io/domleartechtech/gohttp:0.0.6"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.5
+              value: 0.0.6
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: gohttp
   labels:
-    chart: "gohttp-0.0.5"
+    chart: "gohttp-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -131,7 +131,7 @@ releases:
   - issuer:
       cluster: true
 - chart: dev/gohttp
-  version: 0.0.5
+  version: 0.0.6
   name: gohttp
   namespace: jx-staging
 - chart: dev/gohttp


### PR DESCRIPTION
chore: promote gohttp to version 0.0.6 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge