### PR TITLE
chore: promote gohttp to version 0.0.11 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.11-release.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.11-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-15T11:50:12Z"
+  creationTimestamp: "2020-11-15T12:08:44Z"
   deletionTimestamp: null
-  name: 'gohttp-0.0.10'
+  name: 'gohttp-0.0.11'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -14,19 +14,19 @@ spec:
       branch: master
       committer: {}
       message: |
-        release 0.0.10
-      sha: 6cdf8decee4caebae6c3358e69a6089088a06d99
+        release 0.0.11
+      sha: fa1b94030f4f61b164eb28e3c3081a69f06c74f5
     - author: {}
       branch: master
       committer: {}
       message: |
-        dummy commit
-      sha: 304aa3b922f339931bd41f24b68e6e1e2056a9ba
+        change to try and see if the helmfile changes has worked
+      sha: 9f935317af5415f94808d871b2b30e49baf6342a
   gitCloneUrl: https://github.com/mikelear/gohttp.git
   gitHttpUrl: https://github.com/mikelear/gohttp
   gitOwner: mikelear
   gitRepository: gohttp
   name: 'gohttp'
-  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.10
-  version: v0.0.10
+  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.11
+  version: v0.0.11
 status: {}

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gohttp-gohttp
   labels:
     draft: draft-app
-    chart: "gohttp-0.0.10"
+    chart: "gohttp-0.0.11"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: gohttp-gohttp
       containers:
         - name: gohttp
-          image: "gcr.io/domleartechtech/gohttp:0.0.10"
+          image: "gcr.io/domleartechtech/gohttp:0.0.11"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.10
+              value: 0.0.11
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: gohttp
   labels:
-    chart: "gohttp-0.0.10"
+    chart: "gohttp-0.0.11"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -131,7 +131,7 @@ releases:
   - issuer:
       cluster: true
 - chart: dev/gohttp
-  version: 0.0.10
+  version: 0.0.11
   name: gohttp
   namespace: jx-staging
 - chart: dev/gohttp


### PR DESCRIPTION
chore: promote gohttp to version 0.0.11 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge