### PR TITLE
chore: promote angular-jx3-example to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-0.0.1-release.yaml
@@ -1,0 +1,38 @@
+# Source: angular-jx3-example/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-16T23:25:14Z"
+  deletionTimestamp: null
+  name: 'angular-jx3-example-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        release 0.0.1
+      sha: 2c71f61aa65e7386d4c0c6764cd22ff2079d2e30
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        release 0.0.1
+      sha: b2e3151fe487e15f367ce2c75e09c7387e06594a
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        chore: Jenkins X build pack
+      sha: 7177737d837d0b2d3ccc5faf8a1a4a51f7392c22
+  gitCloneUrl: https://github.com/mikelear/angular-jx3-example.git
+  gitHttpUrl: https://github.com/mikelear/angular-jx3-example
+  gitOwner: mikelear
+  gitRepository: angular-jx3-example
+  name: 'angular-jx3-example'
+  releaseNotesURL: https://github.com/mikelear/angular-jx3-example/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-angular-jx3-example-deploy.yaml
+++ b/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-angular-jx3-example-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: angular-jx3-example/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: angular-jx3-example-angular-jx3-example
+  labels:
+    draft: draft-app
+    chart: "angular-jx3-example-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: angular-jx3-example-angular-jx3-example
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: angular-jx3-example-angular-jx3-example
+    spec:
+      serviceAccountName: angular-jx3-example-angular-jx3-example
+      containers:
+        - name: angular-jx3-example
+          image: "gcr.io/domleartechtech/angular-jx3-example:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-angular-jx3-example-sa.yaml
+++ b/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-angular-jx3-example-sa.yaml
@@ -1,0 +1,8 @@
+# Source: angular-jx3-example/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: angular-jx3-example-angular-jx3-example
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-ingress.yaml
+++ b/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: angular-jx3-example/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: angular-jx3-example
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: angular-jx3-example
+              servicePort: 80
+      host: angular-jx3-example-jx-staging.leartech.tech
+  tls:
+    - hosts:
+        - angular-jx3-example-jx-staging.leartech.tech
+      secretName: "tls-leartech-tech-p"

--- a/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-svc.yaml
+++ b/config-root/namespaces/jx-staging/angular-jx3-example/angular-jx3-example-svc.yaml
@@ -1,0 +1,21 @@
+# Source: angular-jx3-example/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: angular-jx3-example
+  labels:
+    chart: "angular-jx3-example-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: angular-jx3-example-angular-jx3-example

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -130,5 +130,9 @@ releases:
   namespace: jx-production
   values:
   - mainDomain: "Y"
+- chart: dev/angular-jx3-example
+  version: 0.0.1
+  name: angular-jx3-example
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote angular-jx3-example to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge