### PR TITLE
chore: promote leartech-website to version 0.0.2 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -134,5 +134,9 @@ releases:
   version: 0.0.1
   name: angular-jx3-example
   namespace: jx-staging
+- chart: dev/leartech-website
+  version: 0.0.2
+  name: leartech-website
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote leartech-website to version 0.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge