### PR TITLE
chore: promote leartech-website to version 0.0.4 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/leartech-website/leartech-website-leartech-website-deploy.yaml
+++ b/config-root/namespaces/jx-staging/leartech-website/leartech-website-leartech-website-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: leartech-website-leartech-website
   labels:
     draft: draft-app
-    chart: "leartech-website-0.0.3"
+    chart: "leartech-website-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: leartech-website-leartech-website
       containers:
         - name: leartech-website
-          image: "gcr.io/domleartechtech/leartech-website:0.0.3"
+          image: "gcr.io/domleartechtech/leartech-website:0.0.4"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.3
+              value: 0.0.4
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/leartech-website/leartech-website-svc.yaml
+++ b/config-root/namespaces/jx-staging/leartech-website/leartech-website-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: leartech-website
   labels:
-    chart: "leartech-website-0.0.3"
+    chart: "leartech-website-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -141,7 +141,7 @@ releases:
   name: gohttp
   namespace: jx-production
 - chart: dev/leartech-website
-  version: 0.0.3
+  version: 0.0.4
   name: leartech-website
   namespace: jx-staging
 - chart: dev/leartech-website


### PR DESCRIPTION
chore: promote leartech-website to version 0.0.4 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge