### PR TITLE
chore: promote gohttp to version 0.0.18 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.18-release.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-0.0.18-release.yaml
@@ -1,0 +1,62 @@
+# Source: gohttp/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-18T19:00:22Z"
+  deletionTimestamp: null
+  name: 'gohttp-0.0.18'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        release 0.0.18
+      sha: dbd972cd6bfe4c734db11f0dd0e8497b65a4e620
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        trigger a build
+      sha: 7c8dfbcdd21df350b5ece6659283063c5236b22a
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        trigger a build
+      sha: bad635c600965d2560c660bee5f35780fcc3cd04
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        change main
+      sha: d021ca96bf78bf4e6a91164025bdc396a97fef1a
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        Trig build by changign main
+      sha: a2d6ad57bac5cc24885f632dab9cd58452faf370
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        Trig build
+      sha: 17927aef8be7b142f68e0bac555020f5db89abae
+    - author: {}
+      branch: master
+      committer: {}
+      message: |
+        Trigg build
+      sha: d482a5e43062b1e15706b896badebeb818ae06e4
+  gitCloneUrl: https://github.com/mikelear/gohttp.git
+  gitHttpUrl: https://github.com/mikelear/gohttp
+  gitOwner: mikelear
+  gitRepository: gohttp
+  name: 'gohttp'
+  releaseNotesURL: https://github.com/mikelear/gohttp/releases/tag/v0.0.18
+  version: v0.0.18
+status: {}

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: gohttp/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gohttp-gohttp
+  labels:
+    draft: draft-app
+    chart: "gohttp-0.0.18"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: gohttp-gohttp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: gohttp-gohttp
+    spec:
+      serviceAccountName: gohttp-gohttp
+      containers:
+        - name: gohttp
+          image: "gcr.io/domleartechtech/gohttp:0.0.18"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.18
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-sa.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-gohttp-sa.yaml
@@ -1,0 +1,8 @@
+# Source: gohttp/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gohttp-gohttp
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-ingress.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: gohttp/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: gohttp
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: gohttp
+              servicePort: 80
+      host: gohttp-jx-staging.leartech.tech
+  tls:
+    - hosts:
+        - gohttp-jx-staging.leartech.tech
+      secretName: "tls-leartech-tech-p"

--- a/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
+++ b/config-root/namespaces/jx-staging/gohttp/gohttp-svc.yaml
@@ -1,0 +1,21 @@
+# Source: gohttp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gohttp
+  labels:
+    chart: "gohttp-0.0.18"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: gohttp-gohttp

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -136,5 +136,9 @@ releases:
   - issuer:
       cluster: true
   - versionStream/charts/jx3/acme/values.yaml.gotmpl
+- chart: dev/gohttp
+  version: 0.0.18
+  name: gohttp
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote gohttp to version 0.0.18 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge